### PR TITLE
Add Support for PHP 8.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.0"
+        "php": "^7.3 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "autoload": {


### PR DESCRIPTION
#### What does this PR do?
Add Support for PHP 8.
Backward Breaking; Remove support for PHP 7.2 and earlier.
Upgrade to PHPUnit 9.

#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

